### PR TITLE
Add tests for global exception handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,16 +29,14 @@
 		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>RELEASE</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>RELEASE</version>
             <scope>compile</scope>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -53,11 +51,6 @@
 			<artifactId>lombok</artifactId>
 			<version>1.18.30</version>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>2.0.1.Final</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/io/github/devtae/taskmanagementsystem/controller/TaskController.java
+++ b/src/main/java/io/github/devtae/taskmanagementsystem/controller/TaskController.java
@@ -2,12 +2,12 @@ package io.github.devtae.taskmanagementsystem.controller;
 
 import io.github.devtae.taskmanagementsystem.model.Task;
 import io.github.devtae.taskmanagementsystem.service.TaskService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/io/github/devtae/taskmanagementsystem/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/devtae/taskmanagementsystem/exception/GlobalExceptionHandler.java
@@ -21,7 +21,10 @@ public class GlobalExceptionHandler {
         // Create a structured error response body
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("timestamp", LocalDateTime.now());
-        body.put("message", "Task not found");
+        body.put("errors", "Task not found");
+
+        // Add logging here to check if the handler is being invoked
+        System.out.println("Handler invoked: " + body);
 
         // Return the response entity with a specific HTTP status
         return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
@@ -42,6 +45,9 @@ public class GlobalExceptionHandler {
 
         body.put("errors", errors);
 
+        // Add logging here to check if the handler is being invoked
+        System.out.println("Handler invoked: " + body);
+
         return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
     }
 
@@ -50,7 +56,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Object> handleAllExceptions(Exception ex, WebRequest request) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("timestamp", LocalDateTime.now());
-        body.put("message", "An error occurred");
+        body.put("errors", "An error occurred");
+
+        // Add logging here to check if the handler is being invoked
+        System.out.println("Handler invoked: " + body);
 
         return new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/io/github/devtae/taskmanagementsystem/model/Task.java
+++ b/src/main/java/io/github/devtae/taskmanagementsystem/model/Task.java
@@ -1,13 +1,13 @@
 package io.github.devtae.taskmanagementsystem.model;
 
+
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import jakarta.validation.constraints.*;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/db_name
-spring.datasource.username=your_username
-spring.datasource.password=your_password
+spring.datasource.url=jdbc:postgresql://localhost:5432/task_management_system
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/io/github/devtae/taskmanagementsystem/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/io/github/devtae/taskmanagementsystem/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,76 @@
+package io.github.devtae.taskmanagementsystem.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.devtae.taskmanagementsystem.controller.TaskController;
+import io.github.devtae.taskmanagementsystem.model.Task;
+import io.github.devtae.taskmanagementsystem.service.TaskService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(controllers = {TaskController.class, GlobalExceptionHandler.class})
+public class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TaskService taskService;
+
+    // Test for TaskNotFoundException handling
+    @Test
+    public void whenTaskNotFoundExceptionThrown_thenRespondWithNotFoundStatus() throws Exception {
+        // Given
+        given(taskService.getTaskById(anyLong())).willThrow(new TaskNotFoundException("Not found"));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/tasks/{id}", 1L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is("Task not found")))
+                .andExpect(jsonPath("$.timestamp", is(notNullValue())));
+    }
+
+    @Test
+    public void whenValidationExceptionThrown_thenRespondWithBadRequestStatus() throws Exception {
+        Task invalidTask = new Task();
+        invalidTask.setTitle(null); // Null title should fail @NotBlank validation
+
+        // Perform a post request with the invalid task object
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/tasks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(invalidTask))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is(400)))
+                .andExpect(jsonPath("$.errors").exists())
+                .andExpect(jsonPath("$.timestamp", is(notNullValue())));
+    }
+
+    @Test
+    public void whenGeneralExceptionThrown_thenRespondWithInternalServerErrorStatus() throws Exception {
+        given(taskService.getTaskById(null)).willThrow(new RuntimeException("Unexpected error"));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/tasks/some-invalid-endpoint")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.errors", is("An error occurred")))
+                .andExpect(jsonPath("$.timestamp", is(notNullValue())));
+    }
+}


### PR DESCRIPTION
- Implements a global exception handler tests. This includes:
  - Specific handling for `TaskNotFoundException`, returning a 404 status code with a clear message.
  - Handling of `MethodArgumentNotValidException` for validation errors, returning detailed field error messages in a 400 response.
  - A generic catch-all exception handle for any other unhandled exceptions, safeguarding against revealing sensitive error details and providing a standard 500 error response.